### PR TITLE
JNI bindings to the new RTMP_ServerIP function

### DIFF
--- a/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
+++ b/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
@@ -53,6 +53,12 @@ public class RtmpClient {
     public native int isConnected();
 
     /**
+     * Returns a string representation of the IP address that the client has connected to.
+     * @return IP address on success. NULL if the client is not initialized. Empty string if client is initialized but no connection has been made.
+     */
+    public native String serverIP();
+    
+    /**
      * closes the connection. Dont forget to call
      * @return 0
      */

--- a/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
+++ b/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
@@ -39,7 +39,7 @@ public class RtmpClient {
      */
     public native int read(byte[] data, int offset, int size);
 
-    public native int write(byte[] data);
+    public native int write(byte[] data, int size);
 
     public native int seek(int seekTime);
 

--- a/rtmp-client/src/main/jni/librtmp-jni.c
+++ b/rtmp-client/src/main/jni/librtmp-jni.c
@@ -85,10 +85,10 @@ JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_read
 /*
  * Class:     net_butterflytv_rtmp_client_RtmpClient
  * Method:    write
- * Signature: ([CI)I
+ * Signature: ([BI)I
  */
 JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_write
-        (JNIEnv * env, jobject thiz, jcharArray data, jint size) {
+        (JNIEnv * env, jobject thiz, jbyteArray data, jint size) {
     jfieldID fid = (*env)->GetFieldID(env, (*env)->GetObjectClass(env, thiz), "rtmp", "J");
     jlong raw_rtmp =  (*env)->GetLongField(env, thiz, fid);
     RTMP *rtmp = (RTMP*)(*(void**)&raw_rtmp);
@@ -96,8 +96,15 @@ JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_write
     if(rtmp == NULL) {
         return -10000;
     }
+    jboolean isCopy;
+    jbyte *elements = (*env)->GetByteArrayElements(env, data, &isCopy);
 
-    return RTMP_Write(rtmp, data, size);
+    jint result = -1;
+    if (elements) {
+        result = RTMP_Write(rtmp, elements, size);
+        (*env)->ReleaseByteArrayElements(env, data, elements, JNI_ABORT);
+    }
+    return result;
 }
 
 /*

--- a/rtmp-client/src/main/jni/librtmp-jni.c
+++ b/rtmp-client/src/main/jni/librtmp-jni.c
@@ -8,7 +8,7 @@
 /*
  * Class:     net_butterflytv_rtmp_client_RtmpClient
  * Method:    open
- * Signature: (Ljava/lang/String;)I
+ * Signature: (Ljava/lang/String;Z)I
  */
 JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_open
         (JNIEnv * env, jobject thiz, jstring url_, jboolean isPublishMode) {
@@ -178,3 +178,18 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_isConnected(JNIEnv *env, jobject th
      }
 }
 
+/*
+ * Class:     net_butterflytv_rtmp_client_RtmpClient
+ * Method:    serverIP
+ * Signature: ()I
+ */
+JNIEXPORT jstring JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_serverIP
+        (JNIEnv * env, jobject thiz) {
+    jfieldID fid = (*env)->GetFieldID(env, (*env)->GetObjectClass(env, thiz), "rtmp", "J");
+    jlong raw_rtmp =  (*env)->GetLongField(env, thiz, fid);
+    RTMP *rtmp = (RTMP*)(*(void**)&raw_rtmp);
+    if (rtmp == NULL) {
+        return NULL;
+    }
+    return (*env)->NewStringUTF(env, RTMP_ServerIP(rtmp));
+}

--- a/rtmp-client/src/main/jni/librtmp-jni.c
+++ b/rtmp-client/src/main/jni/librtmp-jni.c
@@ -181,7 +181,7 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_isConnected(JNIEnv *env, jobject th
 /*
  * Class:     net_butterflytv_rtmp_client_RtmpClient
  * Method:    serverIP
- * Signature: ()I
+ * Signature: ()Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_serverIP
         (JNIEnv * env, jobject thiz) {

--- a/rtmp-client/src/main/jni/librtmp-jni.h
+++ b/rtmp-client/src/main/jni/librtmp-jni.h
@@ -64,7 +64,7 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_open(JNIEnv *env, jobject instance,
  * Method:    serverIP
  * Signature: ()Ljava/lang/String;
  */
-JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_serverIP
+JNIEXPORT jstring JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_serverIP
   (JNIEnv *, jobject);
 
     

--- a/rtmp-client/src/main/jni/librtmp-jni.h
+++ b/rtmp-client/src/main/jni/librtmp-jni.h
@@ -50,10 +50,24 @@ JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_pause
 JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_close
   (JNIEnv *, jobject);
 
+/*
+ * Class:     net_butterflytv_rtmp_client_RtmpClient
+ * Method:    open
+ * Signature: (Ljava/Lang/String;Z)I
+ */
 JNIEXPORT jint JNICALL
 Java_net_butterflytv_rtmp_1client_RtmpClient_open(JNIEnv *env, jobject instance, jstring url,
                                                    jboolean isPublishMode);
 
+/*
+ * Class:     net_butterflytv_rtmp_client_RtmpClient
+ * Method:    serverIP
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_serverIP
+  (JNIEnv *, jobject);
+
+    
 JNIEXPORT jint JNICALL
 Java_net_butterflytv_rtmp_1client_RtmpClient_isConnected(JNIEnv *env, jobject instance);
 

--- a/rtmp-client/src/main/jni/librtmp-jni.h
+++ b/rtmp-client/src/main/jni/librtmp-jni.h
@@ -24,7 +24,7 @@ JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_read
  * Signature: ([CI)I
  */
 JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_write
-  (JNIEnv *, jobject, jcharArray, jint);
+  (JNIEnv *, jobject, jbyteArray, jint);
 
 /*
  * Class:     net_butterflytv_rtmp_client_RtmpClient


### PR DESCRIPTION
This provides the JNI wrapper around the new C functions. It's based on the similar functions that forward calls from Java into C objects.